### PR TITLE
Remove technical visit option from IT ticket form

### DIFF
--- a/setores/ti/templates/abrir_chamado.html
+++ b/setores/ti/templates/abrir_chamado.html
@@ -409,10 +409,6 @@
                     <textarea class="form-control" name="descricao" id="descricao" placeholder="Descreva o problema"></textarea>
                 </div>
 
-                <div class="mb-3">
-                    <label class="form-label">Visita Técnica:</label>
-                    <input class="form-control" type="date" name="data_visita" id="data_visita" />
-                </div>
 
                 <div id="prioridade" class="prioridade"></div>
 


### PR DESCRIPTION
## Purpose
Remove the technical visit option from the IT department's ticket opening page as requested by the user to streamline the ticket creation process.

## Code changes
- Removed the "Visita Técnica" (Technical Visit) form field and its associated date input from the `abrir_chamado.html` template
- Cleaned up the HTML structure by removing the entire div block containing the technical visit date picker
- Added proper newline at end of file

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ea0106be95484d788debd65e4fd51049/pulse-works)

👀 [Preview Link](https://ea0106be95484d788debd65e4fd51049-pulse-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ea0106be95484d788debd65e4fd51049</projectId>-->
<!--<branchName>pulse-works</branchName>-->