### PR TITLE
Center modals in ticket history section

### DIFF
--- a/static/ti/js/painel/historico-chamados-completo.js
+++ b/static/ti/js/painel/historico-chamados-completo.js
@@ -345,7 +345,7 @@ class HistoricoCompletoManager {
         const bsModal = new bootstrap.Modal(modal);
         bsModal.show();
 
-        // Limpar modal após fechar
+        // Limpar modal ap��s fechar
         modal.addEventListener('hidden.bs.modal', () => {
             modal.remove();
         });
@@ -359,7 +359,7 @@ class HistoricoCompletoManager {
         modal.className = 'modal fade';
         modal.setAttribute('tabindex', '-1');
         modal.innerHTML = `
-            <div class="modal-dialog modal-xl">
+            <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
                 <div class="modal-content bg-dark text-white">
                     <div class="modal-header border-secondary">
                         <h5 class="modal-title">

--- a/static/ti/js/painel/historico-chamados-completo.js
+++ b/static/ti/js/painel/historico-chamados-completo.js
@@ -492,7 +492,7 @@ class HistoricoCompletoManager {
         `).join('') || '<p class="text-muted">Nenhum evento registrado na timeline.</p>';
 
         modal.innerHTML = `
-            <div class="modal-dialog modal-lg">
+            <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
                 <div class="modal-content bg-dark text-white">
                     <div class="modal-header border-secondary">
                         <h5 class="modal-title">
@@ -597,7 +597,7 @@ class HistoricoCompletoManager {
         `).join('') || '<p class="text-muted">Nenhum anexo encontrado.</p>';
 
         modal.innerHTML = `
-            <div class="modal-dialog modal-lg">
+            <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
                 <div class="modal-content bg-dark text-white">
                     <div class="modal-header border-secondary">
                         <h5 class="modal-title">

--- a/static/ti/js/painel/historico-chamados.js
+++ b/static/ti/js/painel/historico-chamados.js
@@ -427,7 +427,7 @@ class HistoricoChamados {
         modal.className = 'modal fade';
         modal.setAttribute('tabindex', '-1');
         modal.innerHTML = `
-            <div class="modal-dialog modal-lg">
+            <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
                 <div class="modal-content bg-dark text-white">
                     <div class="modal-header border-secondary">
                         <h5 class="modal-title">


### PR DESCRIPTION
## Purpose

Fix modal positioning issues in the ticket history section where modals were appearing partially off-screen when using 80% browser zoom. The user needed all modals ("ver detalhes", "ver timeline", and "ver anexos") to be properly centered and fully visible regardless of zoom level.

## Code changes

- Added `modal-dialog-centered` class to all modal dialogs in ticket history components
- Added `modal-dialog-scrollable` class to enable proper scrolling for long content
- Updated modal classes in both `historico-chamados.js` and `historico-chamados-completo.js`
- Applied changes to detail, timeline, and attachment modals to ensure consistent centering behavior

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`

🔗 [Edit in Builder.io](https://builder.io/app/projects/59fc8c3af0e94688b1a9cdf5c68a79f8/quantum-forge)

👀 [Preview Link](https://59fc8c3af0e94688b1a9cdf5c68a79f8-quantum-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>59fc8c3af0e94688b1a9cdf5c68a79f8</projectId>-->
<!--<branchName>quantum-forge</branchName>-->